### PR TITLE
Avoid echoing a string containing backslash in Makefile (fixes `make with-mlton` on macOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,14 @@ hamlet.sml: ${BOOTSTRAPFILES} sources.cm
 	@${ECHO} "(* DO NOT EDIT! *)" >$@
 	@${ECHO} "(* Generated from sources.cm (${shell date}) *)" >>$@
 	@${ECHO} >>$@
-	@${ECHO} '${BOOTSTRAPFILES:%=\use "%";}' | tr "\\" "\n" >>$@
+	@${ECHO} '${BOOTSTRAPFILES:%=|use "%";}' | tr "|" "\n" >>$@
 
 hamlet.mlb:
 	@${ECHO} Generating $@
 	@${ECHO} "(* DO NOT EDIT! *)" >$@
 	@${ECHO} "(* Generated from sources.cm (${shell date}) *)" >>$@
 	@${ECHO} >>$@
-	@${ECHO} '$$(SML_LIB)/basis/basis.mlb${FILES:%=\\%}\main/wrap-${SYSTEM}.sml' | tr "\\" "\n" >>$@
+	@${ECHO} '$$(SML_LIB)/basis/basis.mlb${FILES:%=|%}|main/wrap-${SYSTEM}.sml' | tr "|" "\n" >>$@
 
 ################################################################################
 # Create single file


### PR DESCRIPTION
`echo`'s output is implementation-defined if the argument contains a backslash character, and actually it is truncated on `\c` under macOS.

(See [What is this POSIX echo \c? - Unix & Linux Stack Exchange](https://unix.stackexchange.com/questions/565785/what-is-this-posix-echo-c) for details.)

Since the rule to make `hamlet.mlb` contains something like `echo '...\compile-js...'`, `hamlet.mlb` is truncated there and `make with-mlton` produces an empty executable on macOS.

This PR fixes the problem by avoiding use of `\` in the argument of `echo`.


