### PR TITLE
Fix the equality attributes of datatypes named `ref`

### DIFF
--- a/elab/InitialStaticEnv.sml
+++ b/elab/InitialStaticEnv.sml
@@ -39,7 +39,7 @@ struct
   val tyconString = TyCon.fromString "string"
   val tyconChar   = TyCon.fromString "char"
   val tyconList   = TyCon.fromString "list"
-  val tyconRef    = TyCon.fromString "ref"
+  val tyconRef    = Type.tyconRef
   val tyconExn    = TyCon.fromString "exn"
 
 
@@ -52,7 +52,7 @@ struct
   val tString = TyName.tyname(TyCon.toString tyconString, 0, true,  0)
   val tChar   = TyName.tyname(TyCon.toString tyconChar,   0, true,  256)
   val tList   = TyName.tyname(TyCon.toString tyconList,   1, true,  2)
-  val tRef    = TyName.tyname(TyCon.toString tyconRef,    1, true,  1)
+  val tRef    = Type.tRef
   val tExn    = TyName.tyname(TyCon.toString tyconExn,    0, false, 0)
 
   val T0 =

--- a/elab/TYPE-sig.sml
+++ b/elab/TYPE-sig.sml
@@ -81,4 +81,10 @@ sig
   val guessRow             : unit -> RowType
   val rowFromList          : (Lab * Type) list -> RowType
   val findLab              : RowType * Lab -> Type option
+
+
+  (* References *)
+
+  val tyconRef             : IdsCore.TyCon
+  val tRef                 : TyName
 end;

--- a/elab/Type.sml
+++ b/elab/Type.sml
@@ -247,6 +247,9 @@ struct
 
   (* Check for equality type [Section 4.4] *)
 
+  val tyconRef = TyCon.fromString "ref"
+  val tRef = TyName.tyname(TyCon.toString tyconRef, 1, true, 1)
+
   fun admitsEquality(ref tau') = admitsEquality' tau'
   and admitsEquality'(TyVar alpha) =
         TyVar.admitsEquality alpha
@@ -258,7 +261,7 @@ struct
         false
     | admitsEquality'(ConsType(taus, t)) =
         TyName.admitsEquality t andalso List.all admitsEquality taus
-        orelse TyName.toString t = "ref"
+        orelse t = tRef
     | admitsEquality'(Undetermined{eq, ...}) =
         eq orelse raise Type
     | admitsEquality'(Overloaded O) =
@@ -397,7 +400,7 @@ struct
         (case Stamp.compare(TyName.time t, time) of
           GREATER => raise Unify
         | _ =>
-            if not eq orelse TyName.toString t = "ref" then
+            if not eq orelse t = tRef then
               ( List.app (propagate(time, false)) taus; tau' )
             else if TyName.admitsEquality t then
               ( List.app (propagate(time, eq)) taus; tau' )

--- a/valid/ValidCore.sml
+++ b/valid/ValidCore.sml
@@ -191,7 +191,7 @@ struct
 	    val t = #2(Type.toConsType tau)
 	in
 	    if TyName.admitsEquality t then
-		TyName.toString t = "ref" orelse
+		t = tRef orelse
 		VIdMap.all respectsEqualityValStr VE
 	    else
 		true

--- a/valid/ValidModule.sml
+++ b/valid/ValidModule.sml
@@ -213,7 +213,7 @@ struct
 	    val t = #2(Type.toConsType tau)
 	in
 	    if TyName.admitsEquality t then
-		TyName.toString t = "ref" orelse
+		t = tRef orelse
 		VIdMap.all respectsEqualityValStr VE
 	    else
 		true


### PR DESCRIPTION
According to the Definition, a type τ admits equality if it has the form (τ') `ref`. This `ref` is a *type name*, not a *type constructor*. HaMLet, however, checks this criterion in a wrong way: HaMLet considers τ to be an equality type if it has a form (τ') α where α is a type name which originates from a datatype declaration (or specification) for a *type constructor* `ref`. This makes more types to be deemed as equality types. As a consequence, HaMLet reports a *runtime* type error for the following code:

```sml
let
  datatype 'a ref = T of 'a
in
  T 1.0 = T 1.0
end;
```

```
(input 1):4.8-4.15: runtime type error: equality type expected
```

With this PR, HaMLet now reports a *compile-time* type error (as opposed to *runtime*):

```
(input 1):4.8-4.15: type mismatch on application
```

---------

This problem has been found by @minoki (https://twitter.com/mod_poppo/status/1404797375693082660).