### PR TITLE
typo corrections and speculative adjustments in System F

### DIFF
--- a/compile-f/FSyntax.sml
+++ b/compile-f/FSyntax.sml
@@ -12,7 +12,7 @@ struct
 
     datatype kind =                                (* [k] *)
         StarKind                                   (* * *)
-      | ArrowKind                                  (* k -> k *)
+      | ArrowKind of kind * kind                   (* k -> k *)
 
     datatype typ =                                 (* t *)
         VarTyp   of var                            (* a *)
@@ -42,22 +42,22 @@ struct
       | ExnVal   of value * value                  (* exn v v *)
 
     and exp =                                      (* [e] *)
-        ValExp   of value                          (* v *)
-      | SeqExp   of exp * exp                      (* e ; e *)
-      | AppExp   of exp * exp                      (* e e *)
-      | ProjExp  of side * exp                     (* #i e *)
-      | CaseExp  of exp * var * exp * var * exp    (* case e of x. e | x. e *)
+        ValExp    of value                         (* v *)
+      | SeqExp    of exp * exp                     (* e ; e *)
+      | AppExp    of exp * exp                     (* e e *)
+      | ProjExp   of index * exp                   (* #i e *)
+      | CaseExp   of exp * var * exp * var * exp   (* case e of x. e | x. e *)
       | UnrollExp of exp                           (* unroll e *)
-      | InstExp  of exp * typ                      (* e t *)
+      | InstExp   of exp * typ                     (* e t *)
       | UnpackExp of exp * var * var * exp         (* unpack e as <a, x>. e *)
-      | TestExp  of exp * exp * var * exp * exp    (* test e is e x. e | e *)
-      | ThrowExp of exp * tyo                      (* throw e : t *)
-      | CatchExp of exp * var * exp                (* try e catch x. e *)
-      | RefExp   of exp                            (* ref e *)
-      | ReadExp  of exp                            (* !e *)
-      | WriteExp of exp * exp                      (* e := e *)
+      | TestExp   of exp * exp * var * exp * exp   (* test e is e x. e | e *)
+      | ThrowExp  of exp * typ                     (* throw e : t *)
+      | CatchExp  of exp * var * exp               (* try e catch x. e *)
+      | RefExp    of exp                           (* ref e *)
+      | ReadExp   of exp                           (* !e *)
+      | WriteExp  of exp * exp                     (* e := e *)
 
-    fun LetExp(exp1, typ, var, exp2) = AppExp(FunExp(var, typ, exp2), exp1)
+    fun LetExp(exp1, typ, var, exp2) = AppExp(ValExp(FunVal(var, typ, exp2)), exp1)
 end
 
-structure VarMap = FiniteMapFn(type key = string; val compare = String.compare);
+structure VarMap = FinMapFn(type ord_key = string; val compare = String.compare);

--- a/compile-f/F_STATIC-sig.sml
+++ b/compile-f/F_STATIC-sig.sml
@@ -16,7 +16,7 @@ sig
 
     exception Error of string
 
-    val eqTyp :   typ -> typ -> bool
+    val eqTyp   : typ * typ -> bool
     val elabTyp : typ_env * typ -> kind
     val elabVal : typ_env * val_env * value -> typ
     val elabExp : typ_env * val_env * exp -> typ


### PR DESCRIPTION
I made a few small changes to allow the System F files to run in the interpreter.

I thought I should include complimentary sample code to run System F files in the interpreter.

```
use "smlnj-lib/lib-base-sig.sml" ;
use "smlnj-lib/lib-base.sml" ;
use "smlnj-lib/fifo-sig.sml" ;
use "smlnj-lib/fifo.sml" ;
use "smlnj-lib/queue-sig.sml" ;
use "smlnj-lib/queue.sml" ;
use "smlnj-lib/ord-key-sig.sml" ;
use "smlnj-lib/ord-map-sig.sml" ;
use "smlnj-lib/ord-set-sig.sml" ;
use "smlnj-lib/binary-map-fn.sml" ;
use "smlnj-lib/binary-set-fn.sml" ;

use "infrastructure/FIN_SET-sig.sml" ;
use "infrastructure/FinSetFn.sml" ;
use "infrastructure/FIN_MAP-sig.sml" ;
use "infrastructure/FinMapFn.sml" ;

use "compile-f/FSyntax.sml" ;
use "compile-f/F_STATIC-sig.sml" ;
use "compile-f/FStatic.sml" ;
```
